### PR TITLE
Use openai-go client for OpenRouter provider

### DIFF
--- a/pkg/llm/providers/openrouter.go
+++ b/pkg/llm/providers/openrouter.go
@@ -1,16 +1,14 @@
 package providers
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"strings"
 	"time"
 
+	openai "github.com/openai/openai-go/v2"
+	"github.com/openai/openai-go/v2/option"
+	"github.com/openai/openai-go/v2/shared"
 	"go.uber.org/zap"
 )
 
@@ -19,56 +17,8 @@ type OpenRouterProvider struct {
 	apiKey     string
 	model      string
 	httpClient *http.Client
+	client     *openai.Client
 	logger     *zap.Logger
-}
-
-// OpenRouter API specific structs
-type openRouterRequest struct {
-	Model       string              `json:"model"`
-	Messages    []openRouterMessage `json:"messages"`
-	MaxTokens   int                 `json:"max_tokens,omitempty"`
-	Stream      bool                `json:"stream,omitempty"`
-	Temperature float64             `json:"temperature,omitempty"`
-}
-
-type openRouterMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-type openRouterResponse struct {
-	ID      string             `json:"id"`
-	Object  string             `json:"object"`
-	Created int64              `json:"created"`
-	Model   string             `json:"model"`
-	Choices []openRouterChoice `json:"choices"`
-	Usage   openRouterUsage    `json:"usage"`
-}
-
-type openRouterChoice struct {
-	Index        int               `json:"index"`
-	Message      openRouterMessage `json:"message"`
-	Delta        openRouterDelta   `json:"delta,omitempty"`
-	FinishReason string            `json:"finish_reason"`
-}
-
-type openRouterDelta struct {
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
-}
-
-type openRouterUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
-}
-
-type openRouterStreamResponse struct {
-	ID      string             `json:"id"`
-	Object  string             `json:"object"`
-	Created int64              `json:"created"`
-	Model   string             `json:"model"`
-	Choices []openRouterChoice `json:"choices"`
 }
 
 func NewOpenRouterProvider(config Config, logger *zap.Logger) (Provider, error) {
@@ -85,6 +35,14 @@ func NewOpenRouterProvider(config Config, logger *zap.Logger) (Provider, error) 
 		},
 		logger: logger.With(zap.String("provider", "openrouter")),
 	}
+
+	// Initialize OpenAI-compatible client for OpenRouter
+	oaClient := openai.NewClient(
+		option.WithBaseURL(provider.baseURL),
+		option.WithAPIKey(provider.apiKey),
+		option.WithHTTPClient(provider.httpClient),
+	)
+	provider.client = &oaClient
 
 	if err := provider.ValidateConfig(); err != nil {
 		return nil, err
@@ -120,26 +78,21 @@ func (p *OpenRouterProvider) GetSupportedModels() []string {
 }
 
 func (p *OpenRouterProvider) ChatCompletion(ctx context.Context, messages []Message) (*ChatResponse, error) {
-	// Конвертируем в формат OpenRouter
-	orMessages := make([]openRouterMessage, len(messages))
+	oaMessages := make([]openai.ChatCompletionMessageParamUnion, len(messages))
 	for i, msg := range messages {
-		orMessages[i] = openRouterMessage{
-			Role:    msg.Role,
-			Content: msg.Content,
+		role := openai.ChatMessageRoleUser
+		switch msg.Role {
+		case "system":
+			role = openai.ChatMessageRoleSystem
+		case "assistant":
+			role = openai.ChatMessageRoleAssistant
+		case "user":
+			role = openai.ChatMessageRoleUser
 		}
-	}
-
-	req := openRouterRequest{
-		Model:       p.model,
-		Messages:    orMessages,
-		MaxTokens:   1000,
-		Stream:      false,
-		Temperature: 0.7,
-	}
-
-	reqBody, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		oaMessages[i] = &openai.ChatCompletionMessageParam{
+			Role:    role,
+			Content: openai.String(msg.Content),
+		}
 	}
 
 	p.logger.Debug("Sending OpenRouter request",
@@ -147,59 +100,35 @@ func (p *OpenRouterProvider) ChatCompletion(ctx context.Context, messages []Mess
 		zap.Int("messages_count", len(messages)),
 	)
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/chat/completions", bytes.NewBuffer(reqBody))
+	resp, err := p.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model:       shared.ChatModel(p.model),
+		Messages:    oaMessages,
+		MaxTokens:   openai.Int(1000),
+		Temperature: openai.Float64(0.7),
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to get completion: %w", err)
 	}
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
-
-	resp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		p.logger.Error("OpenRouter API error",
-			zap.Int("status_code", resp.StatusCode),
-			zap.String("response_body", string(body)),
-		)
-		return nil, fmt.Errorf("API error: %d - %s", resp.StatusCode, string(body))
-	}
-
-	var orResp openRouterResponse
-	if err := json.NewDecoder(resp.Body).Decode(&orResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	// Конвертируем в универсальный формат
-	return p.convertResponse(&orResp), nil
+	return p.convertResponse(resp), nil
 }
 
 func (p *OpenRouterProvider) ChatCompletionStream(ctx context.Context, messages []Message) (<-chan StreamChunk, error) {
-	// Конвертируем в формат OpenRouter
-	orMessages := make([]openRouterMessage, len(messages))
+	oaMessages := make([]openai.ChatCompletionMessageParamUnion, len(messages))
 	for i, msg := range messages {
-		orMessages[i] = openRouterMessage{
-			Role:    msg.Role,
-			Content: msg.Content,
+		role := openai.ChatMessageRoleUser
+		switch msg.Role {
+		case "system":
+			role = openai.ChatMessageRoleSystem
+		case "assistant":
+			role = openai.ChatMessageRoleAssistant
+		case "user":
+			role = openai.ChatMessageRoleUser
 		}
-	}
-
-	req := openRouterRequest{
-		Model:       p.model,
-		Messages:    orMessages,
-		MaxTokens:   1000,
-		Stream:      true,
-		Temperature: 0.7,
-	}
-
-	reqBody, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		oaMessages[i] = &openai.ChatCompletionMessageParam{
+			Role:    role,
+			Content: openai.String(msg.Content),
+		}
 	}
 
 	p.logger.Debug("Sending streaming OpenRouter request",
@@ -207,94 +136,50 @@ func (p *OpenRouterProvider) ChatCompletionStream(ctx context.Context, messages 
 		zap.Int("messages_count", len(messages)),
 	)
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.baseURL+"/chat/completions", bytes.NewBuffer(reqBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
-	httpReq.Header.Set("Accept", "text/event-stream")
-
-	resp, err := p.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		p.logger.Error("OpenRouter API streaming error",
-			zap.Int("status_code", resp.StatusCode),
-			zap.String("response_body", string(body)),
-		)
-		return nil, fmt.Errorf("API error: %d - %s", resp.StatusCode, string(body))
-	}
+	stream := p.client.Chat.Completions.NewStreaming(ctx, openai.ChatCompletionNewParams{
+		Model:       shared.ChatModel(p.model),
+		Messages:    oaMessages,
+		MaxTokens:   openai.Int(1000),
+		Temperature: openai.Float64(0.7),
+	})
 
 	chunks := make(chan StreamChunk, 100)
-	go p.handleStreamResponse(ctx, resp.Body, chunks)
+
+	go func() {
+		defer close(chunks)
+		defer stream.Close()
+
+		for stream.Next() {
+			resp := stream.Response
+			if len(resp.Choices) > 0 {
+				choice := resp.Choices[0]
+				if choice.Delta.Content != "" {
+					chunks <- StreamChunk{Content: choice.Delta.Content}
+				}
+				if choice.FinishReason != "" {
+					chunks <- StreamChunk{Done: true}
+					return
+				}
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			chunks <- StreamChunk{Error: fmt.Errorf("stream error: %w", err)}
+			return
+		}
+		chunks <- StreamChunk{Done: true}
+	}()
 
 	return chunks, nil
 }
 
-func (p *OpenRouterProvider) handleStreamResponse(ctx context.Context, body io.ReadCloser, chunks chan<- StreamChunk) {
-	defer close(chunks)
-	defer body.Close()
-
-	scanner := bufio.NewScanner(body)
-
-	for scanner.Scan() {
-		select {
-		case <-ctx.Done():
-			chunks <- StreamChunk{Error: ctx.Err()}
-			return
-		default:
-		}
-
-		line := scanner.Text()
-
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-
-		data := strings.TrimPrefix(line, "data: ")
-
-		if data == "[DONE]" {
-			chunks <- StreamChunk{Done: true}
-			return
-		}
-
-		var streamResp openRouterStreamResponse
-		if err := json.Unmarshal([]byte(data), &streamResp); err != nil {
-			p.logger.Warn("Failed to parse stream chunk", zap.Error(err), zap.String("data", data))
-			continue
-		}
-
-		if len(streamResp.Choices) > 0 {
-			choice := streamResp.Choices[0]
-			if choice.Delta.Content != "" {
-				chunks <- StreamChunk{Content: choice.Delta.Content}
-			}
-
-			if choice.FinishReason != "" {
-				chunks <- StreamChunk{Done: true}
-				return
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		chunks <- StreamChunk{Error: fmt.Errorf("scanner error: %w", err)}
-	}
-}
-
-func (p *OpenRouterProvider) convertResponse(orResp *openRouterResponse) *ChatResponse {
-	choices := make([]Choice, len(orResp.Choices))
-	for i, choice := range orResp.Choices {
+func (p *OpenRouterProvider) convertResponse(resp *openai.ChatCompletion) *ChatResponse {
+	choices := make([]Choice, len(resp.Choices))
+	for i, choice := range resp.Choices {
 		choices[i] = Choice{
-			Index: choice.Index,
+			Index: int(choice.Index),
 			Message: Message{
-				Role:    choice.Message.Role,
+				Role:    string(choice.Message.Role),
 				Content: choice.Message.Content,
 			},
 			FinishReason: choice.FinishReason,
@@ -302,13 +187,13 @@ func (p *OpenRouterProvider) convertResponse(orResp *openRouterResponse) *ChatRe
 	}
 
 	return &ChatResponse{
-		ID:      orResp.ID,
-		Model:   orResp.Model,
+		ID:      resp.ID,
+		Model:   resp.Model,
 		Choices: choices,
 		Usage: Usage{
-			PromptTokens:     orResp.Usage.PromptTokens,
-			CompletionTokens: orResp.Usage.CompletionTokens,
-			TotalTokens:      orResp.Usage.TotalTokens,
+			PromptTokens:     int(resp.Usage.PromptTokens),
+			CompletionTokens: int(resp.Usage.CompletionTokens),
+			TotalTokens:      int(resp.Usage.TotalTokens),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- replace custom HTTP code in OpenRouter provider with `openai-go` client
- stream chat responses using library's streaming API

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c3dc1ff6b08323833568d5bd398f34